### PR TITLE
Feature/rest_client: add option that allows to use basic auth instead…

### DIFF
--- a/lib/rest_client.js
+++ b/lib/rest_client.js
@@ -1,44 +1,41 @@
 'use strict';
 
-const OAuth = require('oauth-1.0a');
 const request = require('request');
 const logger = require('./log');
 
 module.exports.RestClient = function (options) {
   let instance = {};
 
-  var servelrUrl = options.url;
-  var oauth = OAuth({
-    consumer: {
-      public: options.consumerKey,
-      secret: options.consumerSecret
-    },
-    signature_method: 'HMAC-SHA1'
-  });
-  var token = {
-    public: options.accessToken,
-    secret: options.accessTokenSecret
-  };
+  let OAuth, oauth, token;
+  if(!options.useBasicAuth){
+    OAuth = require('oauth-1.0a');
+    oauth = OAuth({
+      consumer: {
+        public: options.consumerKey,
+        secret: options.consumerSecret
+      },
+      signature_method: 'HMAC-SHA1'
+    });
+    token = {
+      public: options.accessToken,
+      secret: options.accessTokenSecret
+    };
+  }
 
   function apiCall(request_data, request_token = '') {
     logger.debug('Calling API endpoint: ' + request_data.method + ' ' + request_data.url + ' token: ' + request_token);
-
-    logger.info({
+    const requestOptions = {
       url: request_data.url,
       method: request_data.method,
-      headers: request_token ? { 'Authorization': 'Bearer ' + request_token } : oauth.toHeader(oauth.authorize(request_data, token)),
+      headers: options.useBasicAuth ? { 'AuthType': 'Basic' } : request_token ? { 'Authorization': 'Bearer ' + request_token } : oauth.toHeader(oauth.authorize(request_data, token)),
       json: true,
       body: request_data.body,
-    });
+    }
+    logger.info(requestOptions);
+
     /* eslint no-undef: off*/
     return new Promise(function (resolve, reject) {
-      request({
-        url: request_data.url,
-        method: request_data.method,
-        headers: request_token ? { 'Authorization': 'Bearer ' + request_token } : oauth.toHeader(oauth.authorize(request_data, token)),
-        json: true,
-        body: request_data.body,
-      }, function (error, response, body) {
+      request(requestOptions, function (error, response, body) {
         logger.debug('Response received')
         if (error) {
           logger.error('Error occured: ' + error);
@@ -105,7 +102,7 @@ module.exports.RestClient = function (options) {
   }
 
   function createUrl(resourceUrl) {
-    return servelrUrl + '/' + resourceUrl;
+    return options.url + '/' + resourceUrl;
   }
 
   instance.post = function (resourceUrl, data, request_token = '') {


### PR DESCRIPTION
… of oauth for testing purposes.
Additional Info: As we get **Error 500 undefined**, but in reality it is Error 401, error logging can be improved here. Haven't done that in this commit.